### PR TITLE
Fix clone_value method in gui_geometry/tools.rb to use parent class I…

### DIFF
--- a/lib/gui_geometry/tools.rb
+++ b/lib/gui_geometry/tools.rb
@@ -14,7 +14,7 @@ module Tools
 
   def clone_value(v)
     case v
-    when Fixnum, Bignum, Float then v
+    when Integer, Float then v
     else v.clone
     end
   end


### PR DESCRIPTION
Fix clone_value method in **gui_geometry/tools.rb** to use parent class **Integer** instead of **Fixnum**

**Fixnum** was deprecated in ruby 2.4. We can support both **Fixnum** and **Bignum** by using the parent class **Integer**.

All spec tests still pass

```
            ❯ rspec -cfd

            Point
              init
              +
              clone basic point
              clone complex point
              -
              *
              /
              ==
              <=
              <
              >=
              >
              min
              max
              bound
              .area
              width and height
              line col column

            Rectangle
              defaults
            WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: ArgumentError>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/rsahae/dev/gui_geometry/spec/rectangle_spec.rb:13:in `block (2 levels) in <module:GuiGeo>'.
              invalid init
              clone
              init with one point
              inspect
              contains?
              .overlap?
              .union
              .intersection
              default intersection and union
              .present?
              .blank?
              .bound(point)
              .bound(smaller_rect)
              .overlaps? point
              .contains? point
              .contains? and .overlaps? with nil
              .area
              .y_range and .x_range

            Tools
              min
              max
              bound
              minmax
              easy constructors

            Deprecation Warnings:

            Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/rsahae/dev/gui_geometry/spec/point_spec.rb:8:in `block (2 levels) in <module:GuiGeo>'.

            If you need more of the backtrace for any of these deprecations to
            identify where to make the necessary changes, you can configure
            `config.raise_errors_for_deprecations!`, and it will turn the
            deprecation warnings into errors, giving you the full backtrace.

            1 deprecation warning total

            Finished in 0.03656 seconds (files took 0.37271 seconds to load)
            42 examples, 0 failures

            Coverage report generated for RSpec to /Users/rsahae/dev/gui_geometry/coverage. 245 / 266 LOC (92.11%) covered.
```